### PR TITLE
Default values for analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## next
+
+-   default values set for label and value fields when logging analytics events
+
 ## v1.1.0 (2019-02-12)
 
 -   exported functions from analytics module:

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -32,6 +32,28 @@ afterEach(() => {
     window.webkit = origWebkit;
 });
 
+test('log event with default values', async () => {
+    const anyWebviewMock = givenAndroidWebview();
+
+    const DEFAULT_LABEL = 'null_label';
+    const DEFAULT_VALUE = 0;
+
+    await logEvent({
+        category: 'anyCategory',
+        action: 'anyAction',
+    });
+
+    expect(anyWebviewMock.logEvent).toBeCalledWith(
+        'anyCategory',
+        JSON.stringify({
+            eventCategory: 'anyCategory',
+            eventAction: 'anyAction',
+            eventLabel: DEFAULT_LABEL,
+            eventValue: DEFAULT_VALUE,
+        }),
+    );
+});
+
 test('log event in Android', async () => {
     const androidFirebaseMock = givenAndroidWebview();
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -12,6 +12,9 @@ const CD_SUBSCRIPTION_WITH_IPCOMMS: CustomDimensionIdx = 6; // from sessionInfo
 export const CD_NOVUM_UID: CustomDimensionIdx = 7;
 export const CD_EVENT_VALUE: CustomDimensionIdx = 8;
 
+const DEFAULT_EVENT_LABEL = 'null_label';
+const DEFAULT_EVENT_VALUE = 0;
+
 const withAnalytics = ({
     onAndroid,
     onIos,
@@ -64,6 +67,14 @@ export const logEvent = ({
     }
 
     const name = category;
+
+    if (!label) {
+        label = DEFAULT_EVENT_LABEL;
+    }
+
+    if (!value) {
+        value = DEFAULT_EVENT_VALUE;
+    }
 
     const params = {
         eventCategory: category,


### PR DESCRIPTION
As requested by BI, set default values for label and value fields when logging analytics events.