### PR TITLE
Allow user to choose `event name`

### DIFF
--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -38,13 +38,13 @@ test('log event with default values', async () => {
     const DEFAULT_LABEL = 'null_label';
     const DEFAULT_VALUE = 0;
 
-    await logEvent({
+    await logEvent(name, {
         category: 'anyCategory',
         action: 'anyAction',
     });
 
     expect(anyWebviewMock.logEvent).toBeCalledWith(
-        'anyCategory',
+        name,
         JSON.stringify({
             eventCategory: 'anyCategory',
             eventAction: 'anyAction',
@@ -59,7 +59,7 @@ test('log event in Android', async () => {
 
     const ANY_VALUE = 5;
 
-    await logEvent({
+    await logEvent(name, {
         category: 'anyCategory',
         action: 'anyAction',
         label: 'anyLabel',
@@ -68,7 +68,7 @@ test('log event in Android', async () => {
     });
 
     expect(androidFirebaseMock.logEvent).toBeCalledWith(
-        'anyCategory',
+        name,
         JSON.stringify({
             eventCategory: 'anyCategory',
             eventAction: 'anyAction',
@@ -84,7 +84,7 @@ test('log event in iOS', async () => {
 
     const ANY_VALUE = 5;
 
-    await logEvent({
+    await logEvent(name, {
         category: 'anyCategory',
         action: 'anyAction',
         label: 'anyLabel',
@@ -94,7 +94,7 @@ test('log event in iOS', async () => {
 
     expect(iosFirebaseMock.postMessage).toBeCalledWith({
         command: 'logEvent',
-        name: 'anyCategory',
+        name,
         parameters: {
             eventCategory: 'anyCategory',
             eventAction: 'anyAction',

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -75,13 +75,10 @@ type TrackingEvent = {
     [key: string]: any;
 };
 
-export const logEvent = ({
-    category,
-    action,
-    label,
-    value,
-    ...fieldsObject
-}: TrackingEvent) => {
+export const logEvent = (
+    name: string,
+    {category, action, label, value, ...fieldsObject}: TrackingEvent,
+) => {
     if (!category || !action) {
         console.warn('Analytics event should have "category" and "action"', {
             category,
@@ -90,7 +87,7 @@ export const logEvent = ({
         return Promise.resolve();
     }
 
-    const name = category;
+    //const name = category;
 
     if (!label) {
         label = DEFAULT_EVENT_LABEL;

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -68,6 +68,7 @@ const withAnalytics = ({
 };
 
 type TrackingEvent = {
+    name: string; // Event name, can only contain spaces and underscores
     category: string; // Typically the object that was interacted with (e.g. 'Video')
     action: string; // The type of interaction (e.g. 'play')
     label?: string; // Useful for categorizing events (e.g. 'Fall Campaign')
@@ -76,7 +77,7 @@ type TrackingEvent = {
 };
 
 export const logEvent = (
-    name: string,
+    name: TrackingEvent['name'],
     {category, action, label, value, ...fieldsObject}: TrackingEvent,
 ) => {
     if (!category || !action) {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -77,7 +77,7 @@ type TrackingEvent = {
 };
 
 export const logEvent = (
-    name: TrackingEvent['name'],
+    name: TrackingEvent['name'] | TrackingEvent['category'],
     {category, action, label, value, ...fieldsObject}: TrackingEvent,
 ) => {
     if (!category || !action) {


### PR DESCRIPTION
So far, `event name` is tied to `event category`. 

With this commit the user is free to input the event name, if no name is given, use the event category as the event name.