### PR TITLE
Pass old accessToken to native app

### DIFF
--- a/src/__tests__/sessions-test.ts
+++ b/src/__tests__/sessions-test.ts
@@ -9,10 +9,12 @@ afterEach(() => {
 });
 
 test('webapp requests session renewal to native app', async () => {
-    const newAccessToken = 'any token';
+    const oldAccessToken = 'old token';
+    const newAccessToken = 'new token';
     createFakeAndroidPostMessage({
         checkMessage: message => {
             expect(message.type).toBe('RENEW_SESSION');
+            expect(message.payload.accessToken).toBe(oldAccessToken);
         },
         getResponse: message => ({
             type: message.type,
@@ -21,7 +23,7 @@ test('webapp requests session renewal to native app', async () => {
         }),
     });
 
-    const accessToken = await renewSession();
+    const accessToken = await renewSession(oldAccessToken);
     expect(accessToken).toEqual(newAccessToken);
 });
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -5,10 +5,11 @@ import {postMessageToNativeApp, listenToNativeMessage} from './post-message';
  * When webapp (running inside a webview) receives a 401 api response from server, uses this
  * bridge method to renew the session.
  */
-export const renewSession = (): Promise<string> =>
-    postMessageToNativeApp({type: 'RENEW_SESSION'}).then(
-        ({accessToken}) => accessToken,
-    );
+export const renewSession = (oldAccessToken: string | null): Promise<string> =>
+    postMessageToNativeApp({
+        type: 'RENEW_SESSION',
+        payload: {accessToken: oldAccessToken || null},
+    }).then(({accessToken}) => accessToken);
 
 /**
  * This method is used to listen for session renewals made by native app. Whenever the native app


### PR DESCRIPTION
Native app needs to know if a renew to server is needed.
If native app receives an accessToken different from the one it has, a renew is not needed, just respond with the current native accessToken. If the token received is the same that the one the native app has, it means a renew is needed, so native app needs to go server (/token) to obtain a new accessToken