### PR TITLE
Adding getEsimInfo bridge call

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Alternatively, you can import the library directly from a CDN:
 -   [getAppMetadata](#getAppMetadata)
 -   [setCustomerHash](#setCustomerHash)
 -   [getDiskSpaceInfo](#getDiskSpaceInfo)
+-   [getEsimInfo](#getEsimInfo)
 
 ### isWebViewBridgeAvailable
 
@@ -642,6 +643,17 @@ Return info about how much free disk space the device has
 getDiskSpaceInfo: () => Promise<{availableBytes: number, totalBytes: number}>;
 ```
 
+#### Example
+
+```javascript
+import {getDiskSpaceInfo} from '@tef-novum/webview-bridge';
+
+getDiskSpaceInfo().then(({availableBytes, totalBytes}) => { ... });
+```
+
+-   `availableBytes`: number to see available bytes in the device
+-   `totalBytes`: number to see the total bytes in the device
+
 ### getEsimInfo
 
 Return info about the esim capabilities of the device
@@ -655,13 +667,12 @@ getEsimInfo: () => Promise<{supportsEsim: boolean}>;
 #### Example
 
 ```javascript
-import {getDiskSpaceInfo} from '@tef-novum/webview-bridge';
+import {getEsimInfo} from '@tef-novum/webview-bridge';
 
-getDiskSpaceInfo().then(({availableBytes, totalBytes}) => { ... });
+getEsimInfo().then(({supportsEsim}) => { ... });
 ```
 
--   `availableBytes`: number to see available bytes in the device
--   `totalBytes`: number to see the total bytes in the device
+-   `supportsEsim`: true if the device supports eSIM, false otherwise
 
 ## Error handling
 

--- a/README.md
+++ b/README.md
@@ -642,6 +642,16 @@ Return info about how much free disk space the device has
 getDiskSpaceInfo: () => Promise<{availableBytes: number, totalBytes: number}>;
 ```
 
+### getEsimInfo
+
+Return info about the esim capabilities of the device
+
+-   Available for app versions 12.3 and higher
+
+```typescript
+getEsimInfo: () => Promise<{supportsEsim: boolean}>;
+```
+
 #### Example
 
 ```javascript

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ export {
     dismiss,
     requestVibration,
     getDiskSpaceInfo,
+    getEsimInfo,
 } from './src/device';
 export {
     attachToEmail,

--- a/src/__tests__/device-test.ts
+++ b/src/__tests__/device-test.ts
@@ -214,7 +214,7 @@ test('getEsimInfo', async () => {
             type: 'GET_ESIM_INFO',
             id: msg.id,
             payload: {
-                supportsEsim
+                supportsEsim,
             },
         }),
     });
@@ -222,7 +222,7 @@ test('getEsimInfo', async () => {
     const res = await getEsimInfo();
 
     expect(res).toMatchObject({
-        supportsEsim
+        supportsEsim,
     });
     removeFakeAndroidPostMessage();
 });

--- a/src/__tests__/device-test.ts
+++ b/src/__tests__/device-test.ts
@@ -6,6 +6,7 @@ import {
     dismiss,
     requestVibration,
     getDiskSpaceInfo,
+    getEsimInfo,
 } from '../device';
 import {
     createFakeAndroidPostMessage,

--- a/src/__tests__/device-test.ts
+++ b/src/__tests__/device-test.ts
@@ -202,3 +202,27 @@ test('getDiskSpaceInfo', async () => {
     });
     removeFakeAndroidPostMessage();
 });
+
+test('getEsimInfo', async () => {
+    const supportsEsim = true;
+
+    createFakeAndroidPostMessage({
+        checkMessage: (msg) => {
+            expect(msg.type).toBe('GET_ESIM_INFO');
+        },
+        getResponse: (msg) => ({
+            type: 'GET_ESIM_INFO',
+            id: msg.id,
+            payload: {
+                supportsEsim
+            },
+        }),
+    });
+
+    const res = await getEsimInfo();
+
+    expect(res).toMatchObject({
+        supportsEsim
+    });
+    removeFakeAndroidPostMessage();
+});

--- a/src/device.ts
+++ b/src/device.ts
@@ -55,7 +55,7 @@ export const getEsimInfo = (): Promise<{
     supportsEsim: boolean;
 }> =>
     postMessageToNativeApp({
-        type: 'GET_ESIM_INFO'
+        type: 'GET_ESIM_INFO',
     }).catch(() => ({
         supportsEsim: false,
     }));

--- a/src/device.ts
+++ b/src/device.ts
@@ -55,5 +55,7 @@ export const getEsimInfo = (): Promise<{
     supportsEsim: boolean;
 }> =>
     postMessageToNativeApp({
-        type: 'GET_ESIM_INFO',
-    });
+        type: 'GET_ESIM_INFO'
+    }).catch(() => ({
+        supportsEsim: false,
+    }))

--- a/src/device.ts
+++ b/src/device.ts
@@ -58,4 +58,4 @@ export const getEsimInfo = (): Promise<{
         type: 'GET_ESIM_INFO'
     }).catch(() => ({
         supportsEsim: false,
-    }))
+    }));

--- a/src/device.ts
+++ b/src/device.ts
@@ -50,3 +50,10 @@ export const getDiskSpaceInfo = (): Promise<{
     postMessageToNativeApp({
         type: 'GET_DISK_SPACE_INFO',
     });
+ 
+export const getEsimInfo = (): Promise<{
+    supportsEsim: boolean;
+}> =>
+    postMessageToNativeApp({
+        type: 'GET_ESIM_INFO',
+    });

--- a/src/device.ts
+++ b/src/device.ts
@@ -50,7 +50,7 @@ export const getDiskSpaceInfo = (): Promise<{
     postMessageToNativeApp({
         type: 'GET_DISK_SPACE_INFO',
     });
- 
+
 export const getEsimInfo = (): Promise<{
     supportsEsim: boolean;
 }> =>

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -176,6 +176,11 @@ export type ResponsesFromNativeApp = {
         id: string;
         payload: {availableBytes: number; totalBytes: number};
     };
+    GET_ESIM_INFO: {
+        type: 'GET_ESIM_INFO';
+        id: string;
+        payload: {supportsEsim: boolean};
+    };
 };
 
 export type NativeAppResponsePayload<

--- a/src/webview-bridge-cjs.js.flow
+++ b/src/webview-bridge-cjs.js.flow
@@ -217,3 +217,7 @@ declare export function getDiskSpaceInfo(): Promise<{|
     availableBytes: number,
     totalBytes: number,
 |}>;
+
+declare export function getEsimInfo(): Promise<{|
+    supportsEsim: boolean;
+|}>;


### PR DESCRIPTION
Adding getEsimInfo bridge call:

Method that will receive a boolean that is true if the device supports esim
```
Request → {type: “GET_ESIM_INFO”, id: string} 

Response → {type: “GET_ESIM_INFO”, id: string, payload: {supportsEsim: boolean}} 
```